### PR TITLE
Remove console.log that is visible every re-render

### DIFF
--- a/src/components/slack/SlackCounterGroup.tsx
+++ b/src/components/slack/SlackCounterGroup.tsx
@@ -20,8 +20,6 @@ export const SlackCounterGroup: React.VFC<SlackCounterGroupProps> = ({
     onSelect && onSelect(emoji);
   };
 
-  console.log(active);
-
   return (
     <Hover
       hoverStyle={groupStyleActive}


### PR DESCRIPTION
Everytime the slack counter is rendered, a console.log appears.