### PR TITLE
z-index added to the label

### DIFF
--- a/src/components/facebook/FacebookSelectorEmoji.tsx
+++ b/src/components/facebook/FacebookSelectorEmoji.tsx
@@ -61,6 +61,7 @@ const labelStyle: React.CSSProperties = {
   transform: 'translateX(-50%)',
   transition: '200ms transform cubic-bezier(0.23, 1, 0.32, 1)',
   opacity: '0',
+  zIndex : '1000'
 };
 const iconStyleHover = { transform: 'scale(1.3)' };
 


### PR DESCRIPTION
The label of the emojis was not showing when we add `overflow-x: hidden `  to the parent element so I have added  z-index to the label, it might bring the labels up, I didn't test it yet 

PS: I am directly committing from Github editor