### PR TITLE
Fixing the squeezing problem of the Selector div

### DIFF
--- a/src/components/facebook/FacebookCounter.tsx
+++ b/src/components/facebook/FacebookCounter.tsx
@@ -87,7 +87,8 @@ export const defaultProps: Required<FacebookCounterProps> = {
 };
 
 const counterStyle = {
-  display: 'flex',
+display: 'inline-box',
+  display: '-webkit-inline-box',
   cursor: 'pointer',
   color: '#365899',
   fontFamily: `"San Francisco", -apple-system, BlinkMacSystemFont,


### PR DESCRIPTION
I changed the display from `flex `to `-webkit-inline-box`, cause it solves the squeezing problem, if you not gonna merge it then let me pass styles to it through prop